### PR TITLE
Add get_transceiver_status to API interface

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -818,10 +818,13 @@ class CCmisApi(CmisApi):
         trans_status['rxtotpowerlowalarm_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][6]
         trans_status['rxtotpowerhighwarning_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][7]
         trans_status['rxtotpowerlowwarning_flag'] = self.vdm_dict['Rx Total Power [dBm]'][1][8]
-        trans_status['rxsigpowerhighalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][5]
-        trans_status['rxsigpowerlowalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][6]
-        trans_status['rxsigpowerhighwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][7]
-        trans_status['rxsigpowerlowwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][8]
+        try:
+            trans_status['rxsigpowerhighalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][5]
+            trans_status['rxsigpowerlowalarm_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][6]
+            trans_status['rxsigpowerhighwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][7]
+            trans_status['rxsigpowerlowwarning_flag'] = self.vdm_dict['Rx Signal Power [dBm]'][1][8]
+        except KeyError:
+            pass
         return trans_status
 
     def get_transceiver_pm(self):

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -133,6 +133,14 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def get_transceiver_status(self):
+        """
+        Retrieves transceiver status of this SFP
+        Returns:
+            A dict containing the keys/values
+        """
+        raise NotImplementedError
+
     def get_rx_los(self):
         """
         Retrieves the RX LOS (loss-of-signal) status of this xcvr


### PR DESCRIPTION
> **Note**
> This PR is for internal review.
> This PR serves as dependency for https://github.com/longhuan-cisco/sonic-platform-daemons/pull/2

1. Add get_transceiver_status to API interface
2. Ignore if "Rx Signal Power" related fields not existing.

Plz refer to parent PR for UT.