### PR TITLE
Add get_transceiver_pm API interface

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -183,7 +183,7 @@ class CCmisApi(CmisApi):
         rx_frames_subint_pm = self.xcvr_eeprom.read(consts.RX_FRAMES_SUB_INTERVAL_PM)
         rx_frames_uncorr_err_pm = self.xcvr_eeprom.read(consts.RX_FRAMES_UNCORR_ERR_PM)
         rx_min_frames_uncorr_err_subint_pm = self.xcvr_eeprom.read(consts.RX_MIN_FRAMES_UNCORR_ERR_SUB_INTERVAL_PM)
-        rx_max_frames_uncorr_err_subint_pm = self.xcvr_eeprom.read(consts.RX_MIN_FRAMES_UNCORR_ERR_SUB_INTERVAL_PM)
+        rx_max_frames_uncorr_err_subint_pm = self.xcvr_eeprom.read(consts.RX_MAX_FRAMES_UNCORR_ERR_SUB_INTERVAL_PM)
 
         if (rx_frames_subint_pm != 0) and (rx_frames_pm != 0):
             PM_dict['preFEC_uncorr_frame_ratio_avg'] = rx_frames_uncorr_err_pm*1.0/rx_frames_subint_pm

--- a/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
+++ b/sonic_platform_base/sonic_xcvr/api/xcvr_api.py
@@ -141,6 +141,15 @@ class XcvrApi(object):
         """
         raise NotImplementedError
 
+    def get_transceiver_pm(self):
+        """
+        Retrieves PM for this xcvr
+
+        Returns:
+            A dict containing the keys/values
+        """
+        raise NotImplementedError
+
     def get_rx_los(self):
         """
         Retrieves the RX LOS (loss-of-signal) status of this xcvr


### PR DESCRIPTION
Add get_transceiver_pm API interface

#### Description
1. Add get_transceiver_pm API interface in xcvr_api.py
2. Fix a typo in get_pm_all()

#### How Has This Been Tested?
Plz refer to the parent PR.

#### Additional Information (Optional)
> **Note**
> Please don't merge this PR, it's only for internal review purpose.
> Parent PR: https://github.com/longhuan-cisco/sonic-platform-daemons/pull/3